### PR TITLE
Automate migrations, fixes #10

### DIFF
--- a/Dockerfile.migrant
+++ b/Dockerfile.migrant
@@ -1,0 +1,12 @@
+FROM rust:1.34.1 as cargo-build
+RUN apt-get update
+RUN apt-get install musl-tools -y
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo install migrant --version=0.12.0 --features=postgres --target=x86_64-unknown-linux-musl
+
+FROM alpine:latest
+COPY --from=cargo-build /usr/local/cargo/bin/migrant /bin/migrant
+WORKDIR /etc/migrant
+COPY biketracker-server/Migrant-env.toml ./Migrant.toml
+COPY biketracker-server/migrations ./migrations
+ENTRYPOINT ["migrant"]

--- a/biketracker-server/Migrant-env.toml
+++ b/biketracker-server/Migrant-env.toml
@@ -1,0 +1,18 @@
+# Required, do not edit
+database_type = "postgres"
+
+# Required database info
+database_name = "env:BIKETRACKER_SERVER_Db.Database"
+database_user = "env:BIKETRACKER_SERVER_Db.Username"
+database_password = "env:BIKETRACKER_SERVER_Db.Password"
+
+# Configurable database info
+database_host = "env:BIKETRACKER_SERVER_Db.Host"         # default "localhost"
+database_port = "5432"              # default "5432"
+migration_location = "migrations"  # default "migrations"
+
+# Extra database connection parameters
+# with the format:
+# [database_params]
+# key = "value"
+[database_params]

--- a/charts/biketracker/templates/deployment.yaml
+++ b/charts/biketracker/templates/deployment.yaml
@@ -15,9 +15,30 @@ spec:
         app.kubernetes.io/name: {{ include "biketracker.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      initContainers:
+      - name: migrant
+        image: {{ .Values.images.migrant }}
+        args:
+        - apply
+        - --all
+        env:
+        - name: BIKETRACKER_SERVER_Db.Host
+          value: {{ include "biketracker.fullname" . }}-db
+        - name: BIKETRACKER_SERVER_Db.Database
+          value: biketracker
+        - name: BIKETRACKER_SERVER_Db.Username
+          valueFrom:
+            secretKeyRef:
+              name: biketracker.{{ include "biketracker.fullname" . }}-db.credentials
+              key: username
+        - name: BIKETRACKER_SERVER_Db.Password
+          valueFrom:
+            secretKeyRef:
+              name: biketracker.{{ include "biketracker.fullname" . }}-db.credentials
+              key: password
       containers:
       - name: biketracker
-        image: {{ .Values.image }}
+        image: {{ .Values.images.server }}
         env:
         - name: BIKETRACKER_SERVER_Db.Host
           value: {{ include "biketracker.fullname" . }}-db
@@ -36,10 +57,3 @@ spec:
         ports:
         - containerPort: 4000
           name: http
-      #   volumeMounts:
-      #   - name: blog
-      #     mountPath: /blog
-      # volumes:
-      # - name: config
-      #   secret:
-      #     secretName: {{ include "biketracker.fullname" . }}-config

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 export TILLER_NAMESPACE=biketracker
 export KUBECONFIG=deploy/kubeconfig
 
-docker_tag=registry.kubernetes.etimo.se/biketracker-server:$(git rev-parse HEAD)
+git_commit=$(git rev-parse HEAD)
+docker_tag_server=registry.kubernetes.etimo.se/biketracker-server:$git_commit
+docker_tag_migrant=registry.kubernetes.etimo.se/biketracker-migrant:$git_commit
 
 export HELM_TLS_ENABLE=true
 export HELM_TLS_VERIFY=true
@@ -17,7 +19,9 @@ kubectl get secret/tiller-secret --output=go-template='{{index .data "ca.crt"}}'
 kubectl get secret/tiller-secret --output=go-template='{{index .data "tls.crt"}}' | base64 -d > $HELM_TLS_CERT
 kubectl get secret/tiller-secret --output=go-template='{{index .data "tls.key"}}' | base64 -d > $HELM_TLS_KEY
 
-docker build . -f Dockerfile.server -t $docker_tag
-docker push $docker_tag
+docker build . -f Dockerfile.server -t $docker_tag_server
+docker build . -f Dockerfile.migrant -t $docker_tag_migrant
+docker push $docker_tag_server
+docker push $docker_tag_migrant
 helm init --client-only
-helm upgrade biketracker charts/biketracker --install --namespace biketracker --set-string image=$docker_tag
+helm upgrade biketracker charts/biketracker --install --namespace biketracker --set-string images.server=$docker_tag_server,images.migrant=$docker_tag_migrant


### PR DESCRIPTION
Currently broken because it uses a Migrant build that doesn't include TLS support.